### PR TITLE
remove data folder so that we can mount a volume there

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM redis:alpine
 
 ADD start-redis-server.sh /usr/bin/
 RUN chmod +x /usr/bin/start-redis-server.sh
-
+RUN rm -rf /data
 CMD ["start-redis-server.sh"]


### PR DESCRIPTION
I could not mount a volume with the data folder existing in the docker image.