### PR TITLE
Redis environment options

### DIFF
--- a/start-redis-server.sh
+++ b/start-redis-server.sh
@@ -5,4 +5,11 @@ sysctl net.core.somaxconn=1024
 MAXMEMORY=${FLY_VM_MEMORY_MB:-512}
 MAXMEMORY="$(((($FLY_VM_MEMORY_MB*10)-$FLY_VM_MEMORY_MB)/10))"
 
-redis-server --requirepass $REDIS_PASSWORD --dir /data/ --maxmemory "${MAXMEMORY}mb"
+: ${MAXMEMORY_POLICY:="allkeys-lru"}
+: ${APPENDONLY:="no"}
+
+redis-server --requirepass $REDIS_PASSWORD \
+  --dir /data/ \
+  --maxmemory "${MAXMEMORY}mb" \
+  --maxmemory-policy $MAXMEMORY_POLICY \
+  --appendonly $APPENDONLY


### PR DESCRIPTION
Closes #7 

Allows customising some key config values via ENV vars and sets some sane defaults.