### PR TITLE
Fix Max Memory detection

### DIFF
--- a/start-redis-server.sh
+++ b/start-redis-server.sh
@@ -13,10 +13,10 @@ fi
 # Set maxmemory-policy to 'allkeys-lru' for caching servers that should always evict old keys
 : ${MAXMEMORY_POLICY:="volatile-lru"}
 : ${APPENDONLY:="no"}
-: ${FLY_VM_MEMORY_DB:=512}
+: ${FLY_VM_MEMORY_MB:=512}
 
 # Set maxmemory to 10% of available memory
-MAXMEMORY=$(($FLY_VM_MEMORY_DB*90/100))
+MAXMEMORY=$(($FLY_VM_MEMORY_MB*90/100))
 
 redis-server --requirepass $REDIS_PASSWORD \
   --dir /data/ \


### PR DESCRIPTION
The current script has a typo on the env variable `FLY_VM_MEMORY_DB`, should be `FLY_VM_MEMORY_MB`. Due to this, the current max memory is always set to `512` MB.