### PR TITLE
Update mounts config example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ flyctl volumes create redis_server --region ord
 Created at: 02 Nov 20 19:55 UTC
 ```
 
-To connect this volume to the app, `fly.toml` includes a `[[mounts]]` entry.
+To connect this volume to the app, `fly.toml` includes a `[mounts]` entry.
 
 ```
-[[mounts]]
+[mounts]
 source      = "redis_server"
 destination = "/data"
 ```


### PR DESCRIPTION
`[mounts]` is wrapped in one set of square brackets in the fly.toml example as well as in the docs: https://fly.io/docs/reference/configuration/#the-mounts-section