### PR TITLE
fix(quotes): Add double-quotes for `REDIS_PASSWORD`

### DIFF
--- a/start-redis-server.sh
+++ b/start-redis-server.sh
@@ -7,7 +7,7 @@ sysctl net.core.somaxconn=1024 || true
 
 PW_ARG=""
 if [[ ! -z "${REDIS_PASSWORD}" ]]; then
-  PW_ARG="--requirepass $REDIS_PASSWORD"
+  PW_ARG="--requirepass \"$REDIS_PASSWORD\""
 fi
 
 # Set maxmemory-policy to 'allkeys-lru' for caching servers that should always evict old keys
@@ -20,7 +20,7 @@ fi
 # Set maxmemory to 10% of available memory
 MAXMEMORY=$(($FLY_VM_MEMORY_MB*90/100))
 
-redis-server $PW_ARG \
+redis-server "$PW_ARG" \
   --dir /data/ \
   --maxmemory "${MAXMEMORY}mb" \
   --maxmemory-policy $MAXMEMORY_POLICY \

--- a/start-redis-server.sh
+++ b/start-redis-server.sh
@@ -11,11 +11,11 @@ if [[ ! -z "${REDIS_PASSWORD}" ]]; then
 fi
 
 # Set maxmemory-policy to 'allkeys-lru' for caching servers that should always evict old keys
-: ${MAXMEMORY_POLICY:="volatile-lru"}
-: ${APPENDONLY:="no"}
-: ${FLY_VM_MEMORY_MB:=512}
+: "${MAXMEMORY_POLICY:="volatile-lru"}"
+: "${APPENDONLY:="no"}"
+: "${FLY_VM_MEMORY_MB:=512}"
 if [ "${NOSAVE}" = "" ] ; then
-  : ${SAVE:="3600 1 300 100 60 10000"}
+  : "${SAVE:="3600 1 300 100 60 10000"}"
 fi
 # Set maxmemory to 10% of available memory
 MAXMEMORY=$(($FLY_VM_MEMORY_MB*90/100))
@@ -23,6 +23,6 @@ MAXMEMORY=$(($FLY_VM_MEMORY_MB*90/100))
 redis-server "$PW_ARG" \
   --dir /data/ \
   --maxmemory "${MAXMEMORY}mb" \
-  --maxmemory-policy $MAXMEMORY_POLICY \
-  --appendonly $APPENDONLY \
+  --maxmemory-policy "$MAXMEMORY_POLICY" \
+  --appendonly "$APPENDONLY" \
   --save "$SAVE"


### PR DESCRIPTION
This allows special characters to be used, fixing: https://github.com/fly-apps/redis/issues/3

It will also ensure that the resulting server instance remains accessible when the password has special characters.