### PR TITLE
fix(docker): Double-quote `REDIS_VERSION` Docker ARG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG REDIS_VERSION=6.2.6
-FROM redis:${REDIS_VERSION}-alpine
+FROM redis:"${REDIS_VERSION}"-alpine
 
 COPY start-redis-server.sh /usr/bin/start-redis-server.sh
 


### PR DESCRIPTION
This is related to https://github.com/fly-apps/redis/pull/18, in the context of resolving double-quote escape issues.

There's no known report of this Dockerfile being an issue in the wild, but given https://github.com/fly-apps/redis/pull/18, I felt it would be a good idea to nip it in the bud.